### PR TITLE
Fix: Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,22 @@ This [Zim](https://github.com/zim-desktop-wiki/zim-desktop-wiki "Zim - A Desktop
 
 ```bash
 # step 1 - install dependencies
+# Windows:
+winget install nodejs
+winget install imagemagick
+npm install -g @mermaid-js/mermaid-cli
+
+# Linux:
 apt-get install imagemagick
 npm install -g @mermaid-js/mermaid-cli
 
-# step 1 - install this plugin
+# step 2 - install this plugin
 git clone https://this/repo.git ~/.local/share/zim/plugins/insert_mermaid/
 
 # step 3 - restart Zim to load this plugin
 
 # step 4 - enable this plugin
-# In Edit > Preferences > Plugins tab, you can now tick Insert Image form Mermaid.
+# In Edit > Preferences > Plugins tab, you can now tick Insert Image from Mermaid.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ This [Zim](https://github.com/zim-desktop-wiki/zim-desktop-wiki "Zim - A Desktop
 ```bash
 # step 1 - install dependencies
 # Windows:
+# Note that you will need to refresh the terminal between installing nodejs and running npm, so that the PATH is refreshed
 winget install nodejs
-winget install imagemagick
+winget install --Id=imagemagick.imagemagick
 npm install -g @mermaid-js/mermaid-cli
 
 # Linux:

--- a/__init__.py
+++ b/__init__.py
@@ -15,6 +15,8 @@ logger = logging.getLogger('zim.plugins.insert_mermaid')
 # https://github.com/mermaidjs/mermaid.cli#options
 puppeteer_config = os.path.dirname(os.path.abspath(__file__)) + "/data/puppeteer-config.json"
 mmdc_cmd = ['mmdc', "-p", puppeteer_config]
+# Windows fix: resolve the dependency above without the extension (the mmdc file exists), but use the .cmd command below to run it
+mmdc_cmdwithext = (('mmdc.cmd' if os.name == 'nt' else 'mmdc'), "-p", puppeteer_config)
 convert_cmd = ['convert']
 
 
@@ -56,7 +58,7 @@ class MermaidGenerator(ImageGeneratorClass):
 
         # Call mmdc
         try:
-            mmdc = Application(mmdc_cmd)
+            mmdc = Application(mmdc_cmdwithext)
             mmdc.run(("-i", self.mmd_file, "-o", self.png_file))
         except ApplicationError:
             logger.exception("[PLUGIN:INSERT MERMAID] ApplicationError: mmdc error.")


### PR DESCRIPTION
This fixes support on Windows (at least for me) by forcing execution of `mmdc` via `mmdc.cmd`. I also updated README.md with instructions for installing dependencies on Windows.

I tested this on top of this PR: https://github.com/zim-plugins/insert_mermaid/pull/2  so I would consider that PR a dependency of this one.